### PR TITLE
Enable menu input with nn:hid

### DIFF
--- a/source/nya/utilites/input_mgr.cpp
+++ b/source/nya/utilites/input_mgr.cpp
@@ -72,18 +72,16 @@ namespace nya::hid {
     void setPort(ulong port) { selectedPort = port; } 
 
     void updatePadState() {
-        if (isMouseHold(nn::hid::MouseButton::Left)) { 
-            //nya::nya_log("meow\n");
+        // Update controller states every frame
+        prevControllerState = curControllerState;
+        tryGetContState(&curControllerState, selectedPort);
 
-            prevControllerState = curControllerState;
-            tryGetContState(&curControllerState, selectedPort); 
+        prevhControllerState = curhControllerState;
+        tryGetContState(&curhControllerState, 0x20);
 
-            prevhControllerState = curhControllerState;
-            tryGetContState(&curhControllerState, 0x20); 
-        }
-
+        // Update keyboard and mouse states every frame
         prevKeyboardState = curKeyboardState;
-        nn::hid::GetKeyboardState(&curKeyboardState); 
+        nn::hid::GetKeyboardState(&curKeyboardState);
 
         prevMouseState = curMouseState;
         nn::hid::GetMouseState(&curMouseState);

--- a/source/nya/windows/menu_system.cpp
+++ b/source/nya/windows/menu_system.cpp
@@ -134,8 +134,12 @@ namespace nya {
             if (g_MenuNav.menuVisible) {
                 g_MenuNav.currentState = MenuState::Main;
                 g_MenuNav.selectedOption = 0;
+                // When menu is visible, block game input via HID hook toggle
+                nya::hid::toggleInput = true;
             } else {
                 g_MenuNav.currentState = MenuState::Hidden;
+                // Re-enable game input
+                nya::hid::toggleInput = false;
             }
         }
 

--- a/source/program/imgui_nvn.cpp
+++ b/source/program/imgui_nvn.cpp
@@ -170,8 +170,9 @@ bool nvnImGui::InitImGui() {
         ImguiNvnBackend::InitBackend(initInfo);
 
         nya::hid::initKBM();
-
         nya::hid::setPort(0);
+        // Install HID hooks so we can optionally block game input while menu is open
+        nya::hid::install_hooks();
 
         return true;
     } else { 

--- a/source/program/main.cpp
+++ b/source/program/main.cpp
@@ -3,6 +3,7 @@
 #include "imgui_nvn.h" 
 #include "nya.h"
 #include "imgui.h"
+#include "nya/windows/menu_system.h"
  
 HOOK_DEFINE_TRAMPOLINE(nnMain_hook) { 
     static void Callback() { 
@@ -50,12 +51,19 @@ static void KirunaOverlay() {
     ImGui::PopStyleVar();
 }
 
+// Menu frame: handle input and render the menu each frame
+static void KirunaMenuFrame() {
+    nya::menu::handleInput();
+    nya::menu::renderMenu();
+}
+
 extern "C" void exl_main(void *x0, void *x1) { 
     exl::hook::Initialize();
     nnMain_hook::InstallAtSymbol("nnMain"); 
     nvnImGui::InstallHooks();
     nvnImGui::addDrawFunc(nya::nya_main);
     nvnImGui::addDrawFunc(KirunaOverlay);
+    nvnImGui::addDrawFunc(KirunaMenuFrame);
 }
 
 extern "C" NORETURN void exl_exception_entry() {


### PR DESCRIPTION
Integrate `nn::hid` input for menu navigation and block game input when the menu is open.

---
<a href="https://cursor.com/background-agent?bcId=bc-49a9c40e-ad61-4443-9c9f-a7b25bb97c4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49a9c40e-ad61-4443-9c9f-a7b25bb97c4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

